### PR TITLE
Mf dev

### DIFF
--- a/grismconf/grismconf.py
+++ b/grismconf/grismconf.py
@@ -1,7 +1,5 @@
 import os
-import re
-from pathlib import Path
-from typing import Any, Callable, Tuple
+from typing import Callable
 
 import numpy as np
 import numpy.typing as npt
@@ -48,6 +46,15 @@ class Config:
     """
 
     def __init__(self, filename, DIRFILTER=None):
+        try:
+            fits.open(filename)  # file tpe check...
+            self.__init_DATAMODEL(filename)
+        except OSError:
+            self.__init_GRISMCONF(filename, DIRFILTER=None)
+
+    def __init_DATAMODEL(self, filename):
+        print(f"Loading from datamodel of {filename}")
+
         self._DISPX_data = {}
         self._DISPY_data = {}
         self._DISPL_data = {}
@@ -67,30 +74,8 @@ class Config:
         self.SENS = {}
         self.SENS_data = {}
 
-        # Extent of FOV in detector pixel
-        self.XRANGE = {}
-        self.YRANGE = {}
-
         # Wavelength range of the grism
         self.WRANGE = {}
-
-        self.orders = []
-
-        self.wx: float = 0.0
-        self.wy: float = 0.0
-
-        try:
-            # fits.open(filename)  # file type check... is this necessary?
-            # Annoyingly testing for fits with a large library
-            # Replacing by suffix testing (which is what jwst datamodel does anyways)
-            if Path(filename).suffix.lower() != ".fits":
-                raise OSError("File is not a FITS file")
-            self.__init_DATAMODEL(filename)
-        except OSError:
-            self.__init_GRISMCONF(filename, DIRFILTER=None)
-
-    def __init_DATAMODEL(self, filename: str) -> None:
-        print(f"Loading from datamodel of {filename}")
 
         self._DISPX_data, self._DISPY_data, self._DISPL_data, self.SENS_data = (
             specwcs.specwcs_poly(filename)
@@ -138,17 +123,32 @@ class Config:
         self.GRISM_CONF_PATH = os.path.dirname(GRISM_CONF)
         self.GRISM_CONF_FILE = os.path.basename(GRISM_CONF)
 
+        self.orders = self._get_orders()
+        self._DISPX_data = {}
+        self._DISPY_data = {}
+        self._DISPL_data = {}
+
+        self._INVDISPX_data = {}
+        self._INVDISPY_data = {}
+        self._INVDISPL_data = {}
+
+        self._DISPX_polyname = {}
+        self._DISPY_polyname = {}
+        self._DISPL_polyname = {}
+
+        self._INVDISPX_polyname = {}
+        self._INVDISPY_polyname = {}
+        self._INVDISPL_polyname = {}
+
+        self.SENS = {}
+        self.SENS_data = {}
+
+        # Wavelength range of the grism
+        self.WRANGE = {}
+
         # Extent of FOV in detector pixel
         self.XRANGE = {}
         self.YRANGE = {}
-
-        self.rotation_theta = 0.0
-        self.FWCPOS_REF = None
-        self.POM = None
-        self.POMX = None
-        self.POMY = None
-        self.POM_POLYGON = None
-        self.BCK = None
 
         # Get grism orders from the configuration file
         self.orders = [
@@ -169,28 +169,30 @@ class Config:
         # Get physical size of detector
         self.NAXIS = self._get_value("NAXIS", type=int)
 
+        self.rotation_theta = 0.0
         try:
             self.FWCPOS_REF = float(self._get_value("FWCPOS_REF"))
         except Exception:
-            pass
+            self.FWCPOS_REF = None
 
         # Load the name of a POM file
         try:
             self.POM = os.path.join(self.GRISM_CONF_PATH, self._get_value("POM"))
         except Exception:
-            pass
+            self.POM = None
 
         # Load POMX and POMY polynomials if they are specified
         try:
             self.POMX = np.array(self._get_value("POMX")).astype(float)
         except Exception:
-            pass
+            self.POMX = None
 
         try:
             self.POMY = np.array(self._get_value("POMY")).astype(float)
         except Exception:
-            pass
+            self.POMY = None
 
+        self.POM_POLYGON = None
         if self.POMX is not None and self.POMY is not None:
             if np.isfinite(self.POMX).all() and np.isfinite(self.POMY).all():
                 self.POM_POLYGON = np.array([self.POMX, self.POMY]).transpose()
@@ -717,6 +719,7 @@ class Config:
                 i = int(ws[0].split(str)[-1])
                 if len(ws) - 1 != m:
                     print("Wrong format for ", self.GRISM_CONF, name, order)
+                    "FIXME: sys.exit in the middle of a code!!!! "
                     sys.exit(10)
                 vals = [float(ww) for ww in ws[1:]]
                 arr[i, 0:m] = vals
@@ -762,781 +765,3 @@ class Config:
         sens[-2:] = 0.0
 
         return [wavs, sens]
-
-
-class ConfigDatamodel(Config):
-    def __init__(self, filename: str, **kwargs):
-        """Initialize ConfigDatamodel object from a FITS file."""
-        self._DISPX_data = {}
-        self._DISPY_data = {}
-        self._DISPL_data = {}
-
-        self._INVDISPX_data = {}
-        self._INVDISPY_data = {}
-        self._INVDISPL_data = {}
-
-        self._DISPX_polyname = {}
-        self._DISPY_polyname = {}
-        self._DISPL_polyname = {}
-
-        self._INVDISPX_polyname = {}
-        self._INVDISPY_polyname = {}
-        self._INVDISPL_polyname = {}
-
-        self.SENS = {}
-        self.SENS_data = {}
-
-        # Extent of FOV in detector pixel
-        self.XRANGE = {}
-        self.YRANGE = {}
-
-        # Wavelength range of the grism
-        self.WRANGE = {}
-
-        self.orders = []
-
-        self.wx: float = 0.0
-        self.wy: float = 0.0
-
-        if Path(filename).suffix.lower() != ".fits":
-            raise OSError("File is not a FITS file")
-        self.__init_DATAMODEL(filename)
-
-
-class GrismconfParser(dict):
-    """ " Parser for grism configuration files into a dictionary like object.
-
-    This dictionary object can be used to access multiple keys at onces using pattern matching.
-
-    Attributes
-    ----------
-    mapper : dict
-        A dictionary mapping configuration keys to their respective data types.
-        This is used to convert string values in the configuration file to their
-        appropriate types when parsing the file.
-        defaults to a set of common keys and types, but can be extended /
-        overwritten with `mapper` keyword arguments.
-
-    Methods
-    -------
-    from_content(content: str | list[str], **kwargs) -> dict
-        Parses the content of a grism configuration file from a string or list of strings.
-        Returns a dictionary with the parsed configuration values.
-    from_file(filename: str, **kwargs) -> dict
-        Reads a grism configuration file from disk and parses its content.
-        Returns a dictionary with the parsed configuration values.
-        (Raises OSError if the file does not exist or is not a file)
-    """
-
-    __mapper__: dict[str, Callable | type] = {
-        "NAXIS": int,
-        "DISPL": float,
-        "DISPY": float,
-        "DISPX": float,
-        "XRANGE": float,
-        "YRANGE": float,
-        "POMX": float,
-        "POMY": float,
-        "WEDGE": float,
-        "FWCPOS_REF": float,
-    }
-
-    def __getitem__(self, key: Any) -> Any:
-        """Get the value(s) associated with a key or pattern in the configuration."""
-        if value := super().get(key):
-            return value
-        # not direct match, try pattern search
-        matcher = re.compile(rf"{key}")
-        matches = self.__class__({k: v for k, v in self.items() if matcher.match(k)})
-        if matches:
-            return matches
-        raise KeyError(f"Key '{key}' not found in configuration.")
-
-    @classmethod
-    def from_content(cls, content: str | list[str], **kwargs):
-        """Factory method to create a Config object from a string."""
-        if isinstance(content, str):
-            content = content.strip().split("\n")
-
-        mapper = cls.__mapper__.copy()
-        mapper.update(kwargs.get("mapper", {}))
-
-        data = {}
-
-        for line in content:
-            if line.startswith("#"):
-                continue
-
-            elements = line.strip().split()
-
-            if not elements:
-                continue
-
-            # <name>_<+order>_j should still point to <name>
-            value_mapper = mapper.get(elements[0].split("_")[0], lambda x: x)
-            values = [value_mapper(k) for k in elements[1:]]
-            if not values:
-                data[elements[0]] = None
-            elif len(values) == 1:
-                data[elements[0]] = values[0]
-            else:
-                data[elements[0]] = values
-
-        return cls(data)
-
-    @classmethod
-    def from_file(cls, filename: str, **kwargs):
-        """Factory method to create a Config object from a file."""
-
-        path = Path(filename)
-
-        if not (path.exists() and path.is_file()):
-            raise OSError(f"File {filename} does not exist or is not a file.")
-
-        with path.open("r") as f:
-            content = f.readlines()
-        if not content:
-            raise ValueError(f"File {filename} is empty.")
-
-        return cls.from_content(content, **kwargs)
-
-
-class GrismConf:
-    """Class to read and hold GRISM configuration info from a grismconf file"""
-
-    def __init__(self, filename: str, dirfilter: str | None = None):
-        """Initialize GrismConf object from a grismconf file."""
-
-        # Internals
-        self.source: Path = Path(filename)
-        self.config: GrismconfParser = GrismconfParser.from_file(filename)
-
-        # Get grism orders from the configuration file
-        self.orders: list[str] = [
-            k.split("_")[-1] for k in self.config["BEAM_*"].keys()
-        ]
-
-        # dirfilter --> wx, wy
-        self.wx: float = 0.0
-        self.wy: float = 0.0
-        self.set_dirfilter(dirfilter)
-
-        # Rotation angle
-        self.rotation_theta: float = 0.0
-
-        # get pixel (DISP & INVDISP) coefficients
-        # note: when missing defined as array([], shape=(0, 0), dtype=float64
-        self._disp_data: dict[str, dict[str, np.ndarray]] = self._get_disp_data()
-
-        # shapes of the DISP and INVDISP coefficients per order
-        self._polyname = {}
-        for key in self._disp_data.keys():
-            self._polyname[key] = {}
-            for order in self.orders:
-                self._polyname[key][order] = np.shape(self._disp_data[key][order])
-
-        # get sensitivity data
-        self._sens_data: dict[str, Tuple[np.ndarray, np.ndarray]] = (
-            self._get_sens_data()
-        )
-
-        # set wavelength range for each order
-        self.WRANGE: dict[str, Tuple[float, float]] = self._set_wrange(self._sens_data)
-
-    def get_sensitivity_function(self, order: str) -> interp1d:
-        """Get the sensitivity function for a specific order.
-
-        TODO: Provide a jax-compatible version of this interp1d function.
-        """
-        if order not in self._sens_data:
-            raise ValueError(f"Sensitivity data for order '{order}' not found.")
-        wavs, sens = self._sens_data[order]
-        return interp1d(wavs, sens, bounds_error=False, fill_value=0.0)
-
-    def set_dirfilter(self, dirfilter: str | None = None):
-        """Set the direct filter for this grism configuration."""
-        if dirfilter is not None:
-            # We get the wedge offset values for this direct filter
-            wx, wy = self.config[f"WEDGE_{dirfilter}"]
-        else:
-            wx, wy = 0.0, 0.0
-
-        self.wx = wx
-        self.wy = wy
-
-    def set_rotation(self, fwcpos: float | None = None):
-        """Set the rotation angle based on the FWC position."""
-        if fwcpos is None:
-            return
-        self.rotation_theta = np.radians(fwcpos - self.FWCPOS_REF)  # type: ignore
-
-    def _get_disp_data(self) -> dict[str, dict[str, np.ndarray]]:
-        """Extracts the DISP coefficients from the configuration."""
-        data = {}
-        for key in ("DISPX", "DISPY", "DISPL", "INVDISPX", "INVDISPY", "INVDISPL"):
-            data[key] = {}
-            for order in self.orders:
-                what = re.escape(f"{key}_{order}")
-                try:
-                    data[key][order] = np.vstack(
-                        list(self.config[f"{what}.*"].values())
-                    )
-                except KeyError:
-                    # If no data found for this order, initialize with empty array
-                    data[key][order] = np.empty((0, 0))
-        return data
-
-    def _get_sens_data(self) -> dict[str, Tuple[np.ndarray, np.ndarray]]:
-        """Extracts the sensitivity data from the configuration."""
-        # get sensitivity data
-        data = {}
-        for order in self.orders:
-            data[order] = self._get_sensitivity(order)
-        return data
-
-    @staticmethod
-    def _set_wrange(
-        sens_data: dict[str, Tuple[np.ndarray, np.ndarray]],
-    ) -> dict[str, Tuple[float, float]]:
-        """Set the wavelength range for each order based on the sensitivity data."""
-        wrange = {}
-        for order, (wavs, sens) in sens_data.items():
-            vg = sens > np.max(sens) * 1e-3
-            wmin = np.min(wavs[vg])
-            wmax = np.max(wavs[vg])
-            wrange[order] = (wmin, wmax)
-        return wrange
-
-    def _get_file_path(self, key: str) -> str:
-        """Return the full path for a file specified in the configuration."""
-        if key in self.config:
-            return os.path.join(self.source.parent, self.config[key])
-        else:
-            raise ValueError(f"{key} not defined in the configuration file.")
-
-    def _get_sensitivity(self, order: str) -> Tuple[np.ndarray, np.ndarray]:
-        """Helper function that looks for the name of the sensitivity file,
-        reads it and stores the content in a simple list
-        [WAVELENGTH, SENSITIVITY].
-        """
-        fname = self._get_file_path(f"SENSITIVITY_{order}")
-
-        with fits.open(fname) as fin:
-            wavs = fin[1].data.field("WAVELENGTH")[:] * 1
-            sens = fin[1].data.field("SENSITIVITY")[:] * 1
-
-        # Fix for cases where sensitivity is not zero on edges
-        sens[0:2] = 0.0
-        sens[-2:] = 0.0
-
-        return wavs, sens
-
-    @property
-    def XRANGE(self) -> dict:
-        return {
-            k.replace("XRANGE_", ""): v for k, v in self.config["XRANGE_.*"].items()
-        }
-
-    @property
-    def YRANGE(self) -> dict:
-        return {
-            k.replace("YRANGE_", ""): v for k, v in self.config["YRANGE_.*"].items()
-        }
-
-    @property
-    def BCK(self) -> str | None:
-        """Return the background model file name."""
-        try:
-            return self._get_file_path("BACKGROUND")
-        except ValueError:
-            # If no background is specified, return None
-            return None
-
-    @property
-    def POM(self) -> str | None:
-        """Return the POM file name."""
-        try:
-            return self._get_file_path("POM")
-        except ValueError:
-            # If no POM is specified, return None
-            return None
-
-    @property
-    def NAXIS(self) -> Tuple[int, int]:
-        """Return the physical size of the detector."""
-        if "NAXIS" in self.config:
-            return tuple(self.config["NAXIS"])
-        else:
-            raise ValueError("NAXIS not defined in the configuration file.")
-
-    @property
-    def POM_POLYGON(self) -> np.ndarray:
-        return np.array(
-            [self.config.get("POMX", np.nan), self.config.get("POMY", np.nan)]
-        ).transpose()
-
-    @property
-    def POMX(self) -> float:
-        return self.config.get("POMX", np.nan)
-
-    @property
-    def POMY(self) -> float:
-        return self.config.get("POMY", np.nan)
-
-    @property
-    def FWCPOS_REF(self) -> float | None:
-        """Return the reference position for the FWC."""
-        return self.config.get("FWCPOS_REF", None)
-
-    @property
-    def _DISPL_data(self) -> dict:
-        return self._disp_data["DISPL"]
-
-    @property
-    def _DISPX_data(self) -> dict:
-        return self._disp_data["DISPX"]
-
-    @property
-    def _DISPY_data(self) -> dict:
-        return self._disp_data["DISPY"]
-
-    def rotate_trace(
-        self,
-        dx: float | npt.NDArray[np.float64],
-        dy: float | npt.NDArray[np.float64],
-        theta: float | None = None,
-        origin: Tuple[float, float] = (0, 0),
-    ) -> Tuple[float | npt.NDArray[np.float64], float | npt.NDArray[np.float64]]:
-        """Rotate cartesian coordinates CW about an origin
-
-        Parameters
-        ----------
-        dx, dy : float or `~numpy.ndarray`
-            x and y coordinages
-
-        theta : float
-            CW rotation angle, in radians
-
-        origin : [float,float]
-            Origin about which to rotate
-
-        Returns
-        -------
-        dxr, dyr : float or `~numpy.ndarray`
-            Rotated versions of `dx` and `dy`
-
-        """
-
-        if theta is None:
-            theta = self.rotation_theta
-
-        _mat = np.array(
-            [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]]
-        )
-
-        rot = np.dot(np.array([dx - origin[0], dy - origin[1]]).T, _mat)
-        dxr = rot[:, 0] + origin[0]
-        dyr = rot[:, 1] + origin[1]
-        return dxr, dyr
-
-    def is_inside_POM(
-        self,
-        order: int,
-        xs: npt.NDArray[np.float64],
-        ys: npt.NDArray[np.float64],
-        XRANGE: bool = False,
-    ) -> npt.NDArray[np.bool_]:
-        """Check if points xs,ys are within the POM. Uses self.POM_POLYGON is availaible, otherwise XRANGE,YRANGE"""
-
-        # Use polygon path from matplotlib if available otherwise based on X,Y RANGE
-        if np.isfinite(self.POM_POLYGON).all() and not XRANGE:
-            import matplotlib.path as mpltPath
-
-            path = mpltPath.Path(self.POM_POLYGON)
-            points = np.array([xs, ys]).transpose()
-            return path.contains_points(points)
-
-        xrange = self.XRANGE.get(order)
-        yrange = self.YRANGE.get(order)
-        if xrange is None or yrange is None:
-            raise ValueError(f"XRANGE or YRANGE not defined for order {order}.")
-        xs = np.array(xs)
-        ys = np.array(ys)
-
-        xminus, xplus = xrange
-        yminus, yplus = yrange
-
-        return (
-            (xs < self.NAXIS[1] + xplus)
-            & (xs > xminus)
-            & (ys < self.NAXIS[0] + yplus)
-            & (ys > yminus)
-        )
-
-    def DISPL(
-        self,
-        order: str,
-        x0: float | npt.NDArray[np.float64],
-        y0: float | npt.NDArray[np.float64],
-        t: float | npt.NDArray[np.float64],
-    ) -> npt.NDArray[np.float64]:
-        """Returns the wavelength corresponding to a value t for an object at position x0,y0
-
-        Parameters
-        ----------
-        order : str
-            Order index
-
-        x0, y0 : float or `~numpy.ndarray`
-            x and y coordinates in the direct image
-
-        t : float or `~numpy.ndarray`
-            Value of the t variable (usually 0<t<1)
-
-        Returns
-        -------
-        wav : float or `~numpy.ndarray`
-            wavelength value
-
-        """
-        return poly.POLY[self._polyname["DISPL"][order]](
-            self._disp_data["DISPL"][order], x0, y0, t
-        )
-
-    def DDISPL(
-        self,
-        order: str,
-        x0: float | npt.NDArray[np.float64],
-        y0: float | npt.NDArray[np.float64],
-        t: float | npt.NDArray[np.float64],
-    ) -> npt.NDArray[np.float64]:
-        """Returns the derivative of the wavelength with respect to t for an object at position x0, y0
-
-        Parameters
-        ----------
-        order : str
-            Order index
-
-        x0, y0 : float or `~numpy.ndarray`
-            x and y coordinates in the direct image
-
-        t : float or `~numpy.ndarray`
-            Value of the t variable (usually 0<t<1)
-
-        Returns
-        -------
-        wav : float or `~numpy.ndarray`
-            wavelength value
-
-        """
-        return poly.DPOLY[self._polyname["DISPL"][order]](
-            self._disp_data["DISPL"][order], x0, y0, t
-        )
-
-    def DISPX(
-        self,
-        order: str,
-        x0: float | npt.NDArray[np.float64],
-        y0: float | npt.NDArray[np.float64],
-        t: float | npt.NDArray[np.float64],
-    ) -> npt.NDArray[np.float64]:
-        """Returns the x offset x'-x = DISPL(x0,y0,t) where x0,y0 is the position on the detector, x'-x is the difference between direct and grism image x-coordinates and 0<t<1
-
-        Parameters
-        ----------
-        order : str
-            Order index
-
-        x0, y0 : float or `~numpy.ndarray`
-            Reference position (i.e., in direct image)
-
-        t : float or `~numpy.ndarray`
-            Parameter where to evaluate the trace
-
-        Returns
-        -------
-        dx : float or `~np.ndarray`
-            Trace x-coordinates as a function of `t`
-
-        """
-        return -self.wx + poly.POLY[self._polyname["DISPX"][order]](
-            self._disp_data["DISPX"][order], x0, y0, t
-        )
-
-    def DDISPX(
-        self,
-        order: str,
-        x0: float | npt.NDArray[np.float64],
-        y0: float | npt.NDArray[np.float64],
-        t: float | npt.NDArray[np.float64],
-    ) -> npt.NDArray[np.float64]:
-        """Returns the first derivative of the x offset (x'-x) wrt to t, where x0,y0 is the
-        position on the detector, x'-x is the difference between direct and grism image x-coordinates and 0<t<1
-
-        Parameters
-        ----------
-        order : str
-            Order index
-
-        x0, y0 : float or `~numpy.ndarray`
-            Reference position (i.e., in direct image)
-
-        t : float or `~numpy.ndarray`
-            Parameter where to evaluate the trace
-
-        Returns
-        -------
-        dxdt : float or `~np.ndarray`
-            Trace x-coordinates as a function of `t`
-
-        """
-        return poly.DPOLY[self._polyname["DISPX"][order]](
-            self._disp_data["DISPX"][order], x0, y0, t
-        )
-
-    def DISPY(
-        self,
-        order: str,
-        x0: float | npt.NDArray[np.float64],
-        y0: float | npt.NDArray[np.float64],
-        t: float | npt.NDArray[np.float64],
-    ) -> npt.NDArray[np.float64]:
-        """Returns the y offset (y'-y) wrt to t, where x0,y0 is the
-        position on the detector, y'-y is the difference between direct and grism image y-coordinates and 0<t<1
-
-        Parameters
-        ----------
-        order : str
-            Order index
-
-        x0, y0 : float or `~numpy.ndarray`
-            Reference position (i.e., in direct image)
-
-        t : float or `~numpy.ndarray`
-            Parameter where to evaluate the trace
-
-        Returns
-        -------
-        dydt : float or `~np.ndarray`
-            Trace y-coordinates as a function of `t`
-
-        """
-        return -self.wy + poly.POLY[self._polyname["DISPY"][order]](
-            self._disp_data["DISPY"][order], x0, y0, t
-        )
-
-    def DDISPY(
-        self,
-        order: str,
-        x0: float | npt.NDArray[np.float64],
-        y0: float | npt.NDArray[np.float64],
-        t: float | npt.NDArray[np.float64],
-    ) -> npt.NDArray[np.float64]:
-        """Returns the first derivative of the y offset (y'-y) wrt to t, where x0,y0 is the
-        position on the detector, y'-y is the difference between direct and grism image y-coordinates and 0<t<1
-
-        Parameters
-        ----------
-        order : str
-            Order index
-
-        x0, y0 : float or `~numpy.ndarray`
-            Reference position (i.e., in direct image)
-
-        t : float or `~numpy.ndarray`
-            Parameter where to evaluate the trace
-
-        Returns
-        -------
-        dydt : float or `~np.ndarray`
-            Trace y-coordinates as a function of `t`
-
-        """
-        return poly.DPOLY[self._polyname["DISPY"][order]](
-            self._disp_data["DISPY"][order], x0, y0, t
-        )
-
-    def DISPXY(
-        self,
-        order: str,
-        x0: float | npt.NDArray[np.float64],
-        y0: float | npt.NDArray[np.float64],
-        t: float | npt.NDArray[np.float64],
-        theta: float = 0.0,
-    ) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
-        """Return both `x` and `y` coordinates of a rotated trace
-
-        Parameters
-        ----------
-        order : str
-            Order string
-
-        x0, y0 : float
-            Reference position (i.e., in direct image)
-
-        t : float or `~numpy.ndarray`
-            Parameter where to evaluate the trace
-
-        theta : float
-            CW rotation angle, in radians
-
-        Returns
-        -------
-        dxr, dyr : float or `~np.ndarray`
-            Rotated trace coordinates as a function of `t`
-
-        """
-        return (self.DISPX(order, x0, y0, t), self.DISPY(order, x0, y0, t))
-
-        # Rotate coordinates if theta is not zero
-        # BUG: ROTATE_COORDS does not exist
-        # if np.isclose(theta, 0.):
-        #     return dx, dy
-        #
-        # return self._rotate_coords(dx, dy, theta=theta, origin=[0, 0])
-
-    def INVDISPL(
-        self,
-        order: str,
-        x0: float | npt.NDArray[np.float64],
-        y0: float | npt.NDArray[np.float64],
-        wavelength: float | npt.NDArray[np.float64],
-        t0: npt.NDArray[np.float64] = np.linspace(-1, 2, 40),
-    ) -> npt.NDArray[np.float64]:
-        """Returns the value of 't' that corresponds to a given wavelength for a source at position x0,y0
-
-        Parameters
-        ----------
-        order : str
-            Order string
-
-        x0, y0 : float
-            Reference position (i.e., in direct image)
-
-        l : float or `~numpy.ndarray`
-            Wavelength
-        t0 : `~numpy.ndarray`
-            Independent variable location where to evaluate the trace.
-            For low-order trace shapes, this can be coarsely sampled as
-            in the default.
-
-        Returns
-        -------
-        t : `~numpy.ndarray`
-            `t` value
-
-        """
-        polyname = self._polyname["DISPL"][order]
-        try:
-            polydata = self._disp_data["DISPL"][order]
-            return poly.INVPOLY[polyname](polydata, x0, y0, wavelength)
-        except KeyError:
-            invpolydata = self._disp_data["INVDISPL"][order]
-            if invpolydata.size > 0:
-                return poly.POLY[polyname](invpolydata, x0, y0, wavelength)
-            else:
-                xr = self.DISPL(order, x0, y0, t0)
-                so = np.argsort(xr)
-                interpolator = interp1d(
-                    xr[so],
-                    t0[so],
-                    bounds_error=False,
-                    fill_value="extrapolate",  # type: ignore
-                )
-                return interpolator(wavelength)
-
-    def INVDISPX(
-        self,
-        order: str,
-        x0: float | npt.NDArray[np.float64],
-        y0: float | npt.NDArray[np.float64],
-        dx: float | npt.NDArray[np.float64],
-        t0: npt.NDArray[np.float64] = np.linspace(-1, 2, 40),
-    ) -> npt.NDArray[np.float64]:
-        """Returns the value of 't' that corresponds to a given x-offset for a source at position x0,y0
-
-        Parameters
-        ----------
-        order : str
-            Order string
-
-        x0, y0 : float
-            Reference position (i.e., in direct image)
-
-        dx: float or `~numpy.ndarray`
-            x-offset between source and a given pixel
-        t0 : `~numpy.ndarray`
-            Independent variable location where to evaluate the trace.
-            For low-order trace shapes, this can be coarsely sampled as
-            in the default.
-
-        Returns
-        -------
-        t : `~numpy.ndarray`
-            `t` value
-
-        """
-        polyname = self._polyname["DISPX"][order]
-        try:
-            polydata = self._disp_data["DISPX"][order]
-            return poly.INVPOLY[polyname](polydata, x0, y0, dx + self.wx)
-        except KeyError:
-            invpolydata = self._disp_data["INVDISPX"][order]
-            if invpolydata.size > 0:
-                return poly.POLY[polyname](invpolydata, x0, y0, dx)
-            else:
-                xr = self.DISPX(order, x0, y0, t0)
-                so = np.argsort(xr)
-                interpolator = interp1d(
-                    xr[so],
-                    t0[so],
-                )
-                return interpolator(dx)
-
-    def INVDISPY(
-        self,
-        order: str,
-        x0: float | npt.NDArray[np.float64],
-        y0: float | npt.NDArray[np.float64],
-        dy: float | npt.NDArray[np.float64],
-        t0: npt.NDArray[np.float64] = np.linspace(-1, 2, 40),
-    ) -> npt.NDArray[np.float64]:
-        """Returns the value of 't' that corresponds to a given y-offset for a source at position x0,y0
-
-        Parameters
-        ----------
-        order : str
-            Order string
-
-        x0, y0 : float
-            Reference position (i.e., in direct image)
-
-        dy: float or `~numpy.ndarray`
-            y-offset between source and a given pixel
-        t0 : `~numpy.ndarray`
-            Independent variable location where to evaluate the trace.
-            For low-order trace shapes, this can be coarsely sampled as
-            in the default.
-
-        Returns
-        -------
-        t : `~numpy.ndarray`
-            `t` value
-
-        """
-        polyname = self._polyname["DISPY"][order]
-        try:
-            polydata = self._disp_data["DISPY"][order]
-            return poly.INVPOLY[polyname](polydata, x0, y0, dy + self.wy)
-        except KeyError:
-            invpolydata = self._disp_data["INVDISPY"][order]
-            if invpolydata.size > 0:
-                return poly.POLY[polyname](invpolydata, x0, y0, dy)
-            else:
-                yr = self.DISPY(order, x0, y0, t0)
-                so = np.argsort(yr)
-                interpolator = interp1d(
-                    yr[so],
-                    t0[so],
-                )
-                return interpolator(dy)

--- a/grismconf/grismconf2.py
+++ b/grismconf/grismconf2.py
@@ -1,12 +1,12 @@
 import os
 import re
-from typing import Any, Callable, Tuple, Mapping
+from pathlib import Path
+from typing import Any, Callable, Mapping, Tuple
 
 import numpy as np
 import numpy.typing as npt
 from astropy.io import fits
 from scipy.interpolate import interp1d
-from pathlib import Path
 
 # from . import poly, specwcs
 from grismconf import poly
@@ -38,6 +38,8 @@ class GrismconfParser(dict):
     """
 
     __mapper__: dict[str, Callable | type] = {
+        "FWCPOS_REF": float,
+        # NIRCAM FIELDS
         "NAXIS": int,
         "DISPL": float,
         "DISPY": float,
@@ -47,19 +49,30 @@ class GrismconfParser(dict):
         "POMX": float,
         "POMY": float,
         "WEDGE": float,
-        "FWCPOS_REF": float,
+        # NIRISS FIELDS
+        "BEAM": int,
+        "XOFF": float,
+        "YOFF": float,
+        "MMAG_EXTRACT": int,
+        "DYDX_ORDER": int,
+        "DISP_ORDER": int,
+        "DLDP": float,
+        "DYDX": float,
     }
 
     def __getitem__(self, key: Any) -> Any:
         """Get the value(s) associated with a key or pattern in the configuration."""
-        if value := super().get(key):
-            return value
-        # not direct match, try pattern search
-        matcher = re.compile(rf"{key}")
-        matches = self.__class__({k: v for k, v in self.items() if matcher.match(k)})
-        if matches:
-            return matches
-        raise KeyError(f"Key '{key}' not found in configuration.")
+        try:
+            return super().__getitem__(key)
+        except KeyError:
+            # not direct match, try pattern search
+            matcher = re.compile(rf"{key}")
+            matches = self.__class__(
+                {k: v for k, v in self.items() if matcher.match(k)}
+            )
+            if matches:
+                return matches
+            raise KeyError(f"Key '{key}' not found in configuration.")
 
     @classmethod
     def from_content(cls, content: str | list[str], **kwargs):
@@ -82,7 +95,13 @@ class GrismconfParser(dict):
                 continue
 
             # <name>_<+order>_j should still point to <name>
-            value_mapper = mapper.get(elements[0].split("_")[0], lambda x: x)
+            what = elements[0].split("_")
+            value_mapper = lambda x: x  # noqa: E731, default identity
+            for k in reversed(range(len(what))):
+                key = "_".join(what[:k])
+                if key in mapper:
+                    value_mapper = mapper[key]
+                    break
             values = [value_mapper(k) for k in elements[1:]]
             if not values:
                 data[elements[0]] = None
@@ -110,6 +129,65 @@ class GrismconfParser(dict):
         return cls.from_content(content, **kwargs)
 
 
+def transform_v2Conf(c: GrismconfParser, quiet: bool = False) -> GrismconfParser:
+    """Transform a v2.0 configuration to a v1.0 configuration.
+
+    This function maps the v2.0 order names (A, B, C, ...) to their corresponding
+    v1.0 order values (+1, 0, +2, ...).
+
+    The mapping between the two is hard coded and taken from [Grizly](https://github.com/gbrammer/grizli)
+
+    The detection of v2 scheme is based of the presence of keys like "BEAM[A|B|C|D|E|F]" in the configuration.
+    """
+    v2_order_names = {
+        "A": "+1",
+        "B": "0",
+        "C": "+2",
+        "D": "+3",
+        "E": "-1",
+        "F": "+4",
+    }
+
+    # detect format of the configuration
+    try:
+        assert len(c["BEAM[" + "|".join(v2_order_names) + "]"]) > 0, (
+            "impossible v2 detection error"
+        )
+        if not quiet:
+            print("Detected configuration format: v2.0 (orders defined as A, B, C...)")
+    except KeyError:
+        if not quiet:
+            print("Detected configuration format: v1.0 (orders defined as +<order>)")
+        return c
+
+    # copy over all values not associated with the beam info
+    new_conf = GrismconfParser()
+    beam_matcher_expr = r".*_{order_name}_\d+|.*_{order_name}$|BEAM{order_name}$"
+    order_name = "[" + "".join(v2_order_names) + "]"
+    copy_keys = [
+        k
+        for k in c.keys()
+        if not re.compile(beam_matcher_expr.format(order_name=order_name)).match(k)
+    ]
+    new_conf.update({k: c[k] for k in copy_keys})
+
+    # copy beam info and rename
+    which_beams = [(k, v) for k, v in v2_order_names.items() if f"BEAM{k}" in c]
+    for order_name, order_value in which_beams:
+        try:
+            subdata = c[beam_matcher_expr.format(order_name=order_name)]
+        except KeyError:
+            subdata = {}
+        for key, value in subdata.items():
+            if key.startswith("BEAM"):
+                new_key = f"{key[:-1]}_{order_value}"
+                new_conf[new_key] = [int(k) for k in value]
+                continue
+            new_key = key.replace(f"_{order_name}", f"_{order_value}")
+            new_conf[new_key] = value
+    return new_conf
+
+
 class GrismConf:
     """Class to read and hold GRISM configuration info from a grismconf file"""
 
@@ -135,7 +213,9 @@ class GrismConf:
 
         # get pixel (DISP & INVDISP) coefficients
         # note: when missing defined as array([], shape=(0, 0), dtype=float64
-        self._disp_data: Mapping[str, Mapping[str, npt.NDArray[np.float64]]] = self._get_disp_data()
+        self._disp_data: Mapping[str, Mapping[str, npt.NDArray[np.float64]]] = (
+            self._get_disp_data()
+        )
 
         # shapes of the DISP and INVDISP coefficients per order
         # missing orders will be defined as shape (0, 0)
@@ -146,12 +226,14 @@ class GrismConf:
                 self._polyname[key][order] = np.shape(self._disp_data[key][order])
 
         # get sensitivity data
-        self._sens_data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]] = (
-            self._get_sens_data()
-        )
+        self._sens_data: Mapping[
+            str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]
+        ] = self._get_sens_data()
 
         # set wavelength range for each order
-        self.WRANGE: Mapping[str, Tuple[float, float]] = self._set_wrange(self._sens_data)
+        self.WRANGE: Mapping[str, Tuple[float, float]] = self._set_wrange(
+            self._sens_data
+        )
 
     def get_sensitivity_function(self, order: str) -> interp1d:
         """Get the sensitivity function for a specific order.
@@ -196,7 +278,9 @@ class GrismConf:
                     data[key][order] = np.empty((0, 0))
         return data
 
-    def _get_sens_data(self) -> Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]]:
+    def _get_sens_data(
+        self,
+    ) -> Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]]:
         """Extracts the sensitivity data from the configuration."""
         # get sensitivity data
         data = {}
@@ -206,7 +290,9 @@ class GrismConf:
 
     @staticmethod
     def _set_wrange(
-        sens_data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
+        sens_data: Mapping[
+            str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]
+        ],
     ) -> Mapping[str, Tuple[float, float]]:
         """Set the wavelength range for each order based on the sensitivity data."""
         wrange = {}
@@ -224,7 +310,9 @@ class GrismConf:
         else:
             raise ValueError(f"{key} not defined in the configuration file.")
 
-    def _get_sensitivity(self, order: str) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    def _get_sensitivity(
+        self, order: str
+    ) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
         """Helper function that looks for the name of the sensitivity file,
         reads it and stores the content in a simple list
         [WAVELENGTH, SENSITIVITY].

--- a/grismconf/instrument_transform.py
+++ b/grismconf/instrument_transform.py
@@ -1,0 +1,180 @@
+"""
+Transform instrument parameters to map orientation of intrinsic observation coordinates.
+
+This class is a re-write of [Grizli's
+class](https://github.com/gbrammer/grizli/blob/8e0ae2f89e162ab64fdc6f0b68ffa953f034e266/grizli/grismconf.py#L890)
+to avoid hard coded values and convoluted decision tree.  
+
+In this version, instrumental parameters are taken from json information
+(which currently hard coded in `PARAMS`, but can be made dynamic) and provided as a dictionary.
+"""
+import json
+from typing import Any, Dict, Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+# Parameters per recognized instrument
+# Deals with aliases and default values
+PARAMS = json.loads("""
+{
+    "*": {
+        "facility": "default", 
+        "module": "unknown",
+        "instrument": "unknown",
+        "rotation": 0.0, 
+        "axis": "+x",
+        "array_center": [ 507.5, 507.5 ] 
+    },
+    "NIRCAM": {
+        "facility": "HST", 
+        "array_center": [ 507.5, 507.5 ],
+        "A": {
+            "aliases": { "R": "GRISMR", "C": "GRISMC" },
+            "GRISMR": { "rotation": 0.0, "axis": "+x" },
+            "GRISMC": { "rotation": 90.0, "axis": "+y" }
+        },
+        "B": { 
+            "aliases": { "R": "GRISMR", "C": "GRISMC" },
+            "GRISMR": { "rotation": 180.0, "axis": "-x" },
+            "GRISMC": { "rotation": 90.0, "axis": "+y" }
+        }
+    },
+    "NIRISS": {
+        "facility": "JWST", 
+        "array_center": [ 1024.5, 1024.5 ],
+        "*": {
+            "aliases" : { "R": "GR150R", "C": "GR150C" },
+            "GR150R": { "rotation": 270.0, "axis": "-y" },
+            "GR150C": { "rotation": 180.0, "axis": "-x" }
+        }
+    }
+}
+""")
+
+
+class InstrumentTransformation(dict):
+    """ Transform instrument parameters to map orientation of intrinsic observation coordinates. 
+
+    This class is a re-write of [Grizli's
+    class](https://github.com/gbrammer/grizli/blob/8e0ae2f89e162ab64fdc6f0b68ffa953f034e266/grizli/grismconf.py#L890)
+    to avoid hard coded values and convoluted decision tree.  
+    
+    In this version, instrumental parameters are taken from json information
+    (which currently hard coded in `PARAMS`, but can be made dynamic) and provided as a dictionary.
+
+    example usage:
+
+    >>> InstrumentTransformation("NIRCAM", "A", "R")  # or InstrumentTransformation("NIRCAM", "A", "GRISMR")
+     {'facility': 'HST',
+      'module': 'A',
+      'instrument': 'NIRCAM',
+      'rotation': 0.0,
+      'axis': '+x',
+      'array_center': [507.5, 507.5],
+      'grism': 'GRISMR'}
+    >>> InstrumentTransformation("NIRISS", "*", "R") # or InstrumentTransformation("NIRISS", "*", "GR150R")
+     {'facility': 'JWST',
+      'module': '*',
+      'instrument': 'NIRISS',
+      'rotation': 270.0,
+      'axis': '-y',
+      'array_center': [1024.5, 1024.5],
+      'grism': 'GR150R'}
+    Note: when module does not matter, "*" or anything else can be used. If an instrument is not in the parameters
+    a default transformation is provided.
+    """
+    def __init__(self, instrument: str, module: str, grism: str):
+        super().__init__(self.set_params(instrument, module, grism))
+
+    @classmethod
+    def set_params(cls, instrument: str, module: str, grism: str) -> Dict[str, Any]:
+        """ Set instrument parameters based on the provided instrument, module, and grism. """
+        info = PARAMS["*"].copy()
+        instname, inst_info = cls.resolve_module_name(PARAMS, instrument)
+
+        # If default information return
+        if instname == "*":
+            return info
+
+        info.update(
+            {
+                "facility": inst_info.get("facility", None),
+                "instrument": instname,
+                "array_center": inst_info.get("array_center", None),
+            }
+        )
+
+        module_name, module_info = cls.resolve_module_name(inst_info, module)
+        info["module"] = module_name
+        grism_name, grism_info = cls.resolve_module_name(module_info, grism)
+        info["grism"] = grism_name
+        info.update(grism_info)
+
+        return info
+
+    @staticmethod
+    def resolve_module_name(
+        inst_info: Dict[str, Any], module: str
+    ) -> Tuple[str, Dict[str, Any]]:
+        """ Resolve the module name and its associated parameters. 
+
+        Recognizes aliases and * as default values
+
+        parameters
+        ----------
+        inst_info: Dict[str, Any]
+            Instrument information dictionary.
+        module: str
+            Module name to resolve.
+        
+        Returns
+        -------
+        Tuple[str, Dict[str, Any]]
+            Resolved module name (alias-resolved) and its associated parameters.
+        """
+        aliases = inst_info.get("aliases", {})
+        if module in inst_info:
+            return module, inst_info[module]
+        elif module in aliases:
+            return aliases[module], inst_info[aliases[module]]
+        elif "*" in inst_info:
+            return "*", inst_info["*"]
+        raise LookupError(f"Module {module} not found in {inst_info}")
+
+    def apply_rotation(
+        self,
+        x: float | npt.NDArray[np.float64],
+        y: float | npt.NDArray[np.float64],
+        reverse: bool = False,
+    ) -> npt.NDArray[np.float64]:
+        """
+        Forward transform detector to +x.
+
+        Rotate NIRISS and NIRCam coordinates such that slitless dispersion has
+        wavelength increasing towards +x.
+
+        Parameters
+        ----------
+        x, y : float or array-like
+            Original detector coordinates
+
+        Returns
+        -------
+        x, y : array-like
+            Coordinates in rotated frame
+
+        """
+        theta = self.get("rotation", 0.0) / 180 * np.pi
+        center = self.get("array_center", np.array([0.0, 0.0]))
+
+        if reverse:
+            theta = -theta
+
+        rotmat = np.array(
+            [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]]
+        )
+
+        z = np.array([x, y]).T
+
+        return ((z - center) @ rotmat + center).T

--- a/grismconf/specwcs.py
+++ b/grismconf/specwcs.py
@@ -118,23 +118,28 @@ def get_sensitivity(
         If the sensitivity file does not contain the expected filter, pupil, and order information.
     """
 
-    # We need to get the pixel size of the detector. We also get the PUPIL and FILTER name
-    with fits.open(wfss_file) as fin:
-        pixel_area = fin[1].header["PIXAR_SR"]  # type: ignore[no-untyped-call]
-        pupil = fin[0].header["PUPIL"]  # type: ignore[no-untyped-call]
-        filter = fin[0].header["FILTER"]  # type: ignore[no-untyped-call]
+    # We need to get the pixel size of the detector.
+    # We also get the PUPIL and FILTER name
 
-    m = datamodels.open(wfss_file)
+    # FIXME: Direct approach without datamodel -- general solution needed
+    # with fits.open(wfss_file) as fin:
+    #    pixel_area = fin[1].header["PIXAR_SR"]  # type: ignore[no-untyped-call]
+    #    pupil = fin[0].header["PUPIL"]  # type: ignore[no-untyped-call]
+    #    filter = fin[0].header["FILTER"]  # type: ignore[no-untyped-call]
 
-    sensitivity_file = m.meta.ref_file.photom.name[7:]
+    with datamodels.open(wfss_file) as dm:
+        # parameters = dm.get_crds_parameters()
+        sensitivity_file = dm.meta.ref_file.photom.name[7:]
+        pupil = dm.meta.instrument.pupil
+        filter = dm.meta.instrument.filter
+
     fetch_reffile(sensitivity_file, overwrite=False, show=False)
 
     tab = Table.read(sensitivity_file)
+    pixel_area = tab.meta["PIXAR_SR"]
     ok = (tab["filter"] == filter) & (tab["pupil"] == pupil) & (tab["order"] == order)
-    (
-        w,
-        s,
-    ) = np.asarray(tab[ok][0]["wavelength"]), np.asarray(tab[ok][0]["relresponse"])
+    w = np.asarray(tab[ok][0]["wavelength"])
+    s = np.asarray(tab[ok][0]["relresponse"])
     photmjsr = tab[ok][0]["photmjsr"]
     ok = np.nonzero(w)
     w = w[ok]
@@ -170,39 +175,33 @@ def specwcs_poly(wfss_file, order=1):
     NameError
         If the WFSS file does not contain the required WCS information.
     """
-
-    # Check if the input file has the required WCS information
-    with datamodels.open(wfss_file) as dm:
-        try:
-            dm.meta.ref_file.specwcs.name[7:]
-            dm.meta.ref_file.photom.name[7:]
-            dm.meta.photometry.pixelarea_steradians
-        except Exception:
-            raise NameError(
-                "Failed to find WFSS WCS information in input file. Make sure that the JWST pipeline wcs_assign and photom steps were applied."
-            )
-
     _DISPX_data = {}
     _DISPY_data = {}
     _DISPL_data = {}
     SENS_data = {}
-    with datamodels.open(wfss_file) as tree:
-        t = tree["meta"].wcs.get_transform(
-            from_frame="detector", to_frame="grism_detector"
+
+    with datamodels.open(wfss_file) as dm:
+        t = dm.meta.wcs.get_transform(
+            from_frame="detector",
+            to_frame="grism_detector",
         )[-1]
-        for g, order in enumerate(t.orders):
-            sorder = "{0:+}".format(order)
-            _DISPX_data[sorder] = np.array([reformat_poly(p2d) for p2d in t.xmodels[g]])
-            if len(t.xmodels[g]) == 1:
+        for order, xmodel, ymodel, lmodel in zip(
+            t.orders, t.xmodels, t.ymodels, t.lmodels
+        ):
+            sorder = f"{order:+}"
+            _DISPX_data[sorder] = np.array([reformat_poly(p2d) for p2d in xmodel])
+            if len(xmodel) == 1:
                 _DISPX_data[sorder] = _DISPX_data[sorder][0]
 
-            _DISPY_data[sorder] = np.array([reformat_poly(p2d) for p2d in t.ymodels[g]])
-            if len(t.ymodels[g]) == 1:
+            _DISPY_data[sorder] = np.array([reformat_poly(p2d) for p2d in ymodel])
+            if len(ymodel) == 1:
                 _DISPY_data[sorder] = _DISPY_data[sorder][0]
 
-            _DISPL_data[sorder] = np.array([reformat_poly(p2d) for p2d in t.lmodels[g]])
-            if len(t.lmodels[g]) == 1:
-                _DISPL_data[sorder] = _DISPL_data[sorder][0]
+            # The lmodels are (5,) for the 5 orders, not (5, 3) for NIRISS
+            try:
+                _DISPL_data[sorder] = np.array([reformat_poly(p2d) for p2d in lmodel])
+            except TypeError:
+                _DISPL_data[sorder] = np.array(reformat_poly(lmodel))[0]
 
             SENS_data[sorder] = get_sensitivity(wfss_file, order=order)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ build-backend = "hatchling.build"
 [tool.setuptools.packages.find]
 where = ["."]                 # list of folders that contain the packages (["."] by default)
 include = ["grismconf*"]      # package names should match these glob patterns (["*"] by default)
-exclude = ["unittests"]       # exclude packages matching these glob patterns (empty by default)
+exclude = ["tests"]           # exclude packages matching these glob patterns (empty by default)
 namespaces = true             # to disable scanning PEP 420 namespaces (true by default)
 
 [tool.setuptools.package-data]

--- a/tests/test_instrument_transform.py
+++ b/tests/test_instrument_transform.py
@@ -1,0 +1,231 @@
+import pytest
+import numpy as np
+import numpy.testing as npt
+
+from grisconf.instrument_transform import InstrumentTransformation, PARAMS
+
+
+class TestInstrumentTransformation:
+    """Test suite for InstrumentTransformation class."""
+
+    def test_init_with_valid_params(self):
+        """Test initialization with valid parameters."""
+        # Test NIRCAM A GRISMR
+        transform = InstrumentTransformation("NIRCAM", "A", "GRISMR")
+        assert transform["instrument"] == "NIRCAM"
+        assert transform["module"] == "A"
+        assert transform["grism"] == "GRISMR"
+        assert transform["facility"] == "HST"
+        assert transform["rotation"] == 0.0
+        assert transform["axis"] == "+x"
+        assert transform["array_center"] == [507.5, 507.5]
+
+    def test_init_with_aliases(self):
+        """Test initialization using aliases."""
+        # Test NIRCAM A R (alias for GRISMR)
+        transform = InstrumentTransformation("NIRCAM", "A", "R")
+        assert transform["grism"] == "GRISMR"
+        assert transform["rotation"] == 0.0
+        assert transform["axis"] == "+x"
+
+        # Test NIRCAM A C (alias for GRISMC)
+        transform = InstrumentTransformation("NIRCAM", "A", "C")
+        assert transform["grism"] == "GRISMC"
+        assert transform["rotation"] == 90.0
+        assert transform["axis"] == "+y"
+
+    def test_niriss_configuration(self):
+        """Test NIRISS specific configuration."""
+        # Test NIRISS GR150R
+        transform = InstrumentTransformation("NIRISS", "*", "GR150R")
+        assert transform["instrument"] == "NIRISS"
+        assert transform["facility"] == "JWST"
+        assert transform["rotation"] == 270.0
+        assert transform["axis"] == "-y"
+        assert transform["array_center"] == [1024.5, 1024.5]
+        assert transform["grism"] == "GR150R"
+
+        # Test NIRISS with alias
+        transform = InstrumentTransformation("NIRISS", "*", "R")
+        assert transform["grism"] == "GR150R"
+
+    def test_nircam_modules(self):
+        """Test different NIRCAM modules (A and B)."""
+        # Module A
+        transform_a = InstrumentTransformation("NIRCAM", "A", "GRISMR")
+        assert transform_a["module"] == "A"
+        assert transform_a["rotation"] == 0.0
+
+        # Module B
+        transform_b = InstrumentTransformation("NIRCAM", "B", "GRISMR")
+        assert transform_b["module"] == "B"
+        assert transform_b["rotation"] == 180.0
+        assert transform_b["axis"] == "-x"
+
+    def test_unknown_instrument_defaults(self):
+        """Test behavior with unknown instrument (should use defaults)."""
+        transform = InstrumentTransformation("UNKNOWN", "MODULE", "GRISM")
+        # Should fall back to defaults from "*"
+        assert transform["facility"] == "default"
+        assert transform["rotation"] == 0.0
+        assert transform["axis"] == "+x"
+        assert transform["array_center"] == [507.5, 507.5]
+
+    def test_resolve_module_name_method(self):
+        """Test the resolve_module_name static method."""
+        # Test direct module name
+        module_name, module_info = InstrumentTransformation.resolve_module_name(
+            PARAMS["NIRCAM"]["A"], "GRISMR"
+        )
+        assert module_name == "GRISMR"
+        assert module_info["rotation"] == 0.0
+
+        # Test alias resolution
+        module_name, module_info = InstrumentTransformation.resolve_module_name(
+            PARAMS["NIRCAM"]["A"], "R"
+        )
+        assert module_name == "GRISMR"
+        assert module_info["rotation"] == 0.0
+
+        # Test wildcard fallback
+        module_name, module_info = InstrumentTransformation.resolve_module_name(
+            PARAMS["NIRISS"], "anything"
+        )
+        assert module_name == "*"
+
+    def test_resolve_module_name_error(self):
+        """Test that resolve_module_name raises LookupError for invalid modules."""
+        test_info = {"valid_module": {}, "aliases": {"alias": "valid_module"}}
+        
+        with pytest.raises(LookupError, match="Module invalid not found"):
+            InstrumentTransformation.resolve_module_name(test_info, "invalid")
+
+    def test_apply_rotation_identity(self):
+        """Test apply_rotation with zero rotation (identity transformation)."""
+        transform = InstrumentTransformation("NIRCAM", "A", "GRISMR")  # rotation = 0.0
+        
+        x, y = 100.0, 200.0
+        x_rot, y_rot = transform.apply_rotation(x, y)
+        
+        npt.assert_allclose([x_rot, y_rot], [x, y], rtol=1e-10)
+
+    def test_apply_rotation_90_degrees(self):
+        """Test apply_rotation with 90-degree rotation."""
+        transform = InstrumentTransformation("NIRCAM", "A", "GRISMC")  # rotation = 90.0
+        
+        # Test single point
+        x, y = 100.0, 200.0
+        x_rot, y_rot = transform.apply_rotation(x, y)
+        
+        # For 90-degree rotation around center [507.5, 507.5]:
+        # Expected result can be calculated manually
+        center = np.array([507.5, 507.5])
+        theta = 90.0 / 180 * np.pi
+        rotmat = np.array([[np.cos(theta), -np.sin(theta)], 
+                          [np.sin(theta), np.cos(theta)]])
+        expected = ((np.array([x, y]) - center) @ rotmat + center)
+        
+        npt.assert_allclose([x_rot, y_rot], expected, rtol=1e-10)
+
+    def test_apply_rotation_array_input(self):
+        """Test apply_rotation with array inputs."""
+        transform = InstrumentTransformation("NIRISS", "*", "GR150R")  # rotation = 270.0
+        
+        x = np.array([100.0, 200.0, 300.0])
+        y = np.array([150.0, 250.0, 350.0])
+        
+        x_rot, y_rot = transform.apply_rotation(x, y)
+        
+        # Should return arrays of same shape
+        assert x_rot.shape == x.shape
+        assert y_rot.shape == y.shape
+        assert isinstance(x_rot, np.ndarray)
+        assert isinstance(y_rot, np.ndarray)
+
+    def test_apply_rotation_reverse(self):
+        """Test apply_rotation with reverse=True."""
+        transform = InstrumentTransformation("NIRCAM", "B", "GRISMR")  # rotation = 180.0
+        
+        x, y = 100.0, 200.0
+        
+        # Forward and reverse should be inverses
+        x_rot, y_rot = transform.apply_rotation(x, y)
+        x_back, y_back = transform.apply_rotation(x_rot, y_rot, reverse=True)
+        
+        npt.assert_allclose([x_back, y_back], [x, y], rtol=1e-10)
+
+    def test_apply_rotation_different_centers(self):
+        """Test apply_rotation with different array centers."""
+        # NIRISS has different center than NIRCAM
+        transform_niriss = InstrumentTransformation("NIRISS", "*", "GR150R")
+        transform_nircam = InstrumentTransformation("NIRCAM", "A", "GRISMR")
+        
+        x, y = 1000.0, 1000.0
+        
+        # Same rotation angle but different centers should give different results
+        # (if they had the same rotation angle, which they don't in this case)
+        x_niriss, y_niriss = transform_niriss.apply_rotation(x, y)
+        x_nircam, y_nircam = transform_nircam.apply_rotation(x, y)
+        
+        # Just verify they return valid arrays
+        assert isinstance(x_niriss, (float, np.ndarray))
+        assert isinstance(y_niriss, (float, np.ndarray))
+        assert isinstance(x_nircam, (float, np.ndarray))
+        assert isinstance(y_nircam, (float, np.ndarray))
+
+    def test_dictionary_interface(self):
+        """Test that the class behaves as a dictionary."""
+        transform = InstrumentTransformation("NIRCAM", "A", "GRISMR")
+        
+        # Test dictionary access
+        assert "instrument" in transform
+        assert transform.get("rotation") == 0.0
+        assert transform.get("nonexistent", "default") == "default"
+        
+        # Test modification
+        transform["custom_param"] = "test_value"
+        assert transform["custom_param"] == "test_value"
+
+    def test_comprehensive_parameter_combinations(self):
+        """Test various parameter combinations for comprehensive coverage."""
+        test_cases = [
+            ("NIRCAM", "A", "R", "GRISMR", 0.0, "+x"),
+            ("NIRCAM", "A", "C", "GRISMC", 90.0, "+y"),
+            ("NIRCAM", "B", "R", "GRISMR", 180.0, "-x"),
+            ("NIRCAM", "B", "C", "GRISMC", 90.0, "+y"),
+            ("NIRISS", "*", "R", "GR150R", 270.0, "-y"),
+            ("NIRISS", "*", "C", "GR150C", 180.0, "-x"),
+            ("NIRISS", "any", "GR150R", "GR150R", 270.0, "-y"),
+        ]
+        
+        for instrument, module, grism_input, expected_grism, expected_rotation, expected_axis in test_cases:
+            transform = InstrumentTransformation(instrument, module, grism_input)
+            assert transform["grism"] == expected_grism, f"Failed for {instrument}/{module}/{grism_input}"
+            assert transform["rotation"] == expected_rotation, f"Failed rotation for {instrument}/{module}/{grism_input}"
+            assert transform["axis"] == expected_axis, f"Failed axis for {instrument}/{module}/{grism_input}"
+
+    def test_set_params_classmethod(self):
+        """Test the set_params class method directly."""
+        params = InstrumentTransformation.set_params("NIRCAM", "A", "GRISMR")
+        
+        assert isinstance(params, dict)
+        assert params["instrument"] == "NIRCAM"
+        assert params["module"] == "A"
+        assert params["grism"] == "GRISMR"
+        assert params["facility"] == "HST"
+
+    def test_edge_cases(self):
+        """Test edge cases and boundary conditions."""
+        # Test with empty strings (should fall back to defaults)
+        transform = InstrumentTransformation("", "", "")
+        assert transform["facility"] == "default"
+        
+        # Test rotation at array center (should be identity)
+        transform = InstrumentTransformation("NIRCAM", "A", "GRISMC")  # 90 degree rotation
+        center = transform["array_center"]
+        x_rot, y_rot = transform.apply_rotation(center[0], center[1])
+        npt.assert_allclose([x_rot, y_rot], center, rtol=1e-10)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
* add v2 parsing (A, B, C --> +1, 0, -1)
    * automatic unit test incomplete but tested against https://zenodo.org/records/7628094
    * very different format on top of renaming BEAM orders
* add `InstrumentTransform`, formerly `JwstDispersionTransform`, in Grizli
    * Simplification of the original code and extraction of hard-coded values/decision trees
* WIP: 
    * updating the GrismConf class to take the NIRISS information for transformations (different names in config)